### PR TITLE
Authentication API to support back channel basic authentication

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.api.core/pom.xml
+++ b/components/org.wso2.carbon.identity.local.auth.api.core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>identity-local-auth-api</artifactId>
         <groupId>org.wso2.carbon.identity.local.auth.api</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -68,10 +68,6 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.idp.mgt</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -109,8 +105,6 @@
 
                             org.wso2.carbon.idp.mgt; version="${carbon.identity.framework.imp.pkg.version}",
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.framework.imp.pkg.version}",
-                            org.wso2.carbon.identity.application.authentication.framework.*;
-                            version="${carbon.identity.framework.imp.pkg.version}",
                             org.wso2.carbon.identity.application.common.model;
                             version="${carbon.identity.framework.imp.pkg.version}",
 

--- a/components/org.wso2.carbon.identity.local.auth.api.core/pom.xml
+++ b/components/org.wso2.carbon.identity.local.auth.api.core/pom.xml
@@ -104,6 +104,7 @@
                             !org.wso2.carbon.identity.local.auth.api.core.internal,
                             org.wso2.carbon.identity.local.auth.api.core.*; version="${project.version}",
                         </Export-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/AuthManagerImpl.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/AuthManagerImpl.java
@@ -281,8 +281,8 @@ public class AuthManagerImpl implements AuthManager {
 
         String errorCode = errorMsgContext.getErrorCode();
         String reason = null;
-        if (errorCode.contains(":")) {
-            String[] errorCodeReason = errorCode.split(":");
+        if (errorCode.contains(AuthAPIConstants.ERROR_REASON_SEPARATOR)) {
+            String[] errorCodeReason = errorCode.split(AuthAPIConstants.ERROR_REASON_SEPARATOR);
             errorCode = errorCodeReason[0];
             if (errorCodeReason.length > 1) {
                 reason = errorCodeReason[1];

--- a/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/JWTAuthTokenGenerator.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/JWTAuthTokenGenerator.java
@@ -101,13 +101,9 @@ public class JWTAuthTokenGenerator implements AuthTokenGenerator {
         long currentTime = Calendar.getInstance().getTimeInMillis();
         long expireIn = currentTime + 1000 * validityPeriod;
 
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet();
-        jwtClaimsSet.setIssuer(issuer);
-        jwtClaimsSet.setSubject(authenticatedUser.toString());
-        jwtClaimsSet.setIssueTime(new Date(currentTime));
-        jwtClaimsSet.setExpirationTime(new Date(expireIn));
-        jwtClaimsSet.setJWTID(UUID.randomUUID().toString());
-        jwtClaimsSet.setClaim(AuthAPIConstants.JWT_CLAIM_NONCE, generateNonce());
+        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder().issuer(issuer).subject(authenticatedUser.toString())
+                .issueTime(new Date(currentTime)).expirationTime(new Date(expireIn)).jwtID(UUID.randomUUID().toString
+                        ()).claim(AuthAPIConstants.JWT_CLAIM_NONCE, generateNonce()).build();
 
         return jwtClaimsSet;
     }

--- a/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/constants/AuthAPIConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/constants/AuthAPIConstants.java
@@ -41,6 +41,7 @@ public class AuthAPIConstants {
     public static final String LOCKED_REASON = "lockedReason";
 
     public static final String AUTH_TOKEN = "AuthToken";
+    public static final String ERROR_REASON_SEPARATOR = ":";
 
 
     public enum Error {

--- a/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/constants/AuthAPIConstants.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/constants/AuthAPIConstants.java
@@ -40,6 +40,8 @@ public class AuthAPIConstants {
     public static final String REMAINING_ATTEMPTS = "remainingAttempts";
     public static final String LOCKED_REASON = "lockedReason";
 
+    public static final String AUTH_TOKEN = "AuthToken";
+
 
     public enum Error {
 
@@ -82,4 +84,7 @@ public class AuthAPIConstants {
         VIA_AUTHORIZATION_HEADER, VIA_REQUEST_BODY;
     }
 
+    private AuthAPIConstants() {
+
+    }
 }

--- a/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/exception/AuthAPIClientException.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/exception/AuthAPIClientException.java
@@ -42,13 +42,13 @@ public class AuthAPIClientException extends AuthAPIException {
         super(message, errorCode);
     }
 
-    public AuthAPIClientException(String message, String errorCode, HashMap<String,String> properties) {
+    public AuthAPIClientException(String message, String errorCode, Map<String,String> properties) {
 
         super(message, errorCode);
         this.properties = properties;
     }
 
-    public AuthAPIClientException(String message, String errorCode, ErrorType errorType, HashMap<String, String>
+    public AuthAPIClientException(String message, String errorCode, ErrorType errorType, Map<String, String>
             properties) {
 
         super(message, errorCode);
@@ -62,7 +62,7 @@ public class AuthAPIClientException extends AuthAPIException {
         this.properties = properties;
     }
 
-    public AuthAPIClientException(String message, String errorCode, ErrorType errorType, HashMap<String, String>
+    public AuthAPIClientException(String message, String errorCode, ErrorType errorType, Map<String, String>
             properties, Throwable cause) {
 
         super(message, errorCode, cause);

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>identity-local-auth-api</artifactId>
         <groupId>org.wso2.carbon.identity.local.auth.api</groupId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -40,8 +40,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/java/org/wso2/carbon/identity/local/auth/api/endpoint/impl/AuthenticateApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/java/org/wso2/carbon/identity/local/auth/api/endpoint/impl/AuthenticateApiServiceImpl.java
@@ -64,7 +64,9 @@ public class AuthenticateApiServiceImpl extends AuthenticateApiService {
                         (credentials);
                 return Response.ok().entity(successResponseDTO).build();
             } else {
-                throw new AuthAPIClientException(AuthAPIConstants.Error.ERROR_INVALID_AUTH_REQUEST.getMessage(), AuthAPIConstants.Error.ERROR_INVALID_AUTH_REQUEST.getCode(), AuthAPIClientException.ErrorType.BAD_REQUEST);
+                throw new AuthAPIClientException(AuthAPIConstants.Error.ERROR_INVALID_AUTH_REQUEST.getMessage(),
+                        AuthAPIConstants.Error.ERROR_INVALID_AUTH_REQUEST.getCode(), AuthAPIClientException.ErrorType
+                        .BAD_REQUEST);
 
             }
         } catch (AuthAPIClientException e) {

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/java/org/wso2/carbon/identity/local/auth/api/endpoint/util/AuthAPIEndpointUtil.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/java/org/wso2/carbon/identity/local/auth/api/endpoint/util/AuthAPIEndpointUtil.java
@@ -87,7 +87,7 @@ public class AuthAPIEndpointUtil {
 
         ErrorDTO errorDTO = getErrorDTO(AuthEndpointConstants.STATUS_BAD_REQUEST_MESSAGE_DEFAULT, description, code,
                 properties);
-        logDebug(log, e);
+        logDebug(AuthEndpointConstants.STATUS_BAD_REQUEST_MESSAGE_DEFAULT, log, e);
         return new BadRequestException(errorDTO);
     }
 
@@ -106,7 +106,7 @@ public class AuthAPIEndpointUtil {
 
         ErrorDTO errorDTO = getErrorDTO(AuthEndpointConstants.STATUS_NOT_ACCEPTABLE_MESSAGE_DEFAULT, description,
                 code, properties);
-        logDebug(log, e);
+        logDebug(AuthEndpointConstants.STATUS_NOT_ACCEPTABLE_MESSAGE_DEFAULT, log, e);
         return new NotAcceptableException(errorDTO);
     }
 
@@ -125,7 +125,7 @@ public class AuthAPIEndpointUtil {
 
         ErrorDTO errorDTO = getErrorDTO(AuthEndpointConstants.STATUS_NOT_FOUND_MESSAGE_DEFAULT, description, code,
                 properties);
-        logDebug(log, e);
+        logDebug(AuthEndpointConstants.STATUS_NOT_FOUND_MESSAGE_DEFAULT, log, e);
         return new NotFoundException(errorDTO);
     }
 
@@ -158,10 +158,10 @@ public class AuthAPIEndpointUtil {
         log.error(throwable.getMessage(), throwable);
     }
 
-    private static void logDebug(Log log, Throwable throwable) {
+    private static void logDebug(String message, Log log, Throwable throwable) {
 
         if (log.isDebugEnabled()) {
-            log.debug(AuthEndpointConstants.STATUS_BAD_REQUEST_MESSAGE_DEFAULT, throwable);
+            log.debug(message, throwable);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.wso2.carbon.identity.local.auth.api</groupId>
     <artifactId>identity-local-auth-api</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Identity - Authentication API</name>
     <url>http://wso2.org</url>
@@ -231,11 +231,6 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
-                <version>${carbon.identity.framework.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.thetransactioncompany.wso2</groupId>
                 <artifactId>cors-filter</artifactId>
                 <version>${cors.filter.version}</version>
@@ -290,8 +285,8 @@
                 <inherited>true</inherited>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -307,8 +307,8 @@
         <commons-logging.imp.pkg.version>[1.2,2.0)</commons-logging.imp.pkg.version>
         <commons-codec.version>1.4.0.wso2v1</commons-codec.version>
 
-        <nimbusds.version>2.26.1.wso2v3</nimbusds.version>
-        <nimbusds.imp.pkg.version>[2.26.1,3.0.0)</nimbusds.imp.pkg.version>
+        <nimbusds.version>5.8.0.wso2v1</nimbusds.version>
+        <nimbusds.imp.pkg.version>[5.8.0,6.0.0)</nimbusds.imp.pkg.version>
         <json-smart.version>1.3</json-smart.version>
 
         <eclipse.osgi.version>3.5.100.v20160504-1419</eclipse.osgi.version>


### PR DESCRIPTION
## Purpose
Resolves wso2/product-is#3316
This PR includes necessary updates to bundle the Authentication API implementation with the latest product version.

## Goals
This Authentication API is introduced to support authentication over a backchannel mechanism, without posting user credentials over the user agent. Authentication API implementation is to be shipped with the product.

## Approach
The authentication API supports basic authentication over two mechanisms.

- HTTP basic authentication scheme (Base64 encoded user credentials in Authorization header)
- User credentials in request body

Upon successful authentication the API will return a signed JWT that will include authenticated subject info.
This PR updates JWT dependency versions and improve error handling and debug logs from the initial implementation.
