### PR TITLE
Fix credential extraction in the api

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/AuthManagerImpl.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/AuthManagerImpl.java
@@ -102,7 +102,7 @@ public class AuthManagerImpl implements AuthManager {
             if (splitValues.length == 2) {
                 byte[] decodedBytes = Base64.decodeBase64(splitValues[1].trim().getBytes());
                 String credentialString = new String(decodedBytes, StandardCharsets.UTF_8);
-                String[] splitCredentials = credentialString.split(":");
+                String[] splitCredentials = credentialString.split(":", 2);
                 if (splitCredentials.length == 2) {
                     String username = splitCredentials[0];
                     String password = splitCredentials[1];


### PR DESCRIPTION
## Purpose
> Properly split the credentials. This will handle the cases where the password has ":" characters.

Resolves https://github.com/wso2/product-is/issues/4321