### PR TITLE
Remove guava dependency duplicated in webapp libs

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/pom.xml
@@ -130,6 +130,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -140,6 +144,7 @@
         <dependency>
             <groupId>commons-lang.wso2</groupId>
             <artifactId>commons-lang</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>


### PR DESCRIPTION
## Proposed changes in this pull request
This is done for the CXF3 dependency upgrade effort. It removes guava jars that get packed unnecessarily inside the lib folder of webapps.