### PR TITLE
Add user session management rest API endpoint

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/pom.xml
@@ -88,6 +88,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.user.session</artifactId>
+            <scope>provided</scope>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
             <scope>provided</scope>

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/pom.xml
@@ -91,7 +91,7 @@
             <groupId>org.wso2.carbon.identity.governance</groupId>
             <artifactId>org.wso2.carbon.identity.user.session</artifactId>
             <scope>provided</scope>
-            <version>1.0.1</version>
+            <version>${carbon.identity.user.session.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/gen/java/org/wso2/carbon/identity/local/auth/api/endpoint/SessionApi.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/gen/java/org/wso2/carbon/identity/local/auth/api/endpoint/SessionApi.java
@@ -1,0 +1,86 @@
+package org.wso2.carbon.identity.local.auth.api.endpoint;
+
+import io.swagger.annotations.ApiParam;
+import org.apache.cxf.jaxrs.ext.MessageContext;
+import org.wso2.carbon.identity.local.auth.api.endpoint.dto.AllSessionsDTO;
+import org.wso2.carbon.identity.local.auth.api.endpoint.factories.SessionApiServiceFactory;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+@Path("/session")
+@Consumes({ "application/json" })
+@Produces({ "application/json" })
+@io.swagger.annotations.Api(value = "/session", description = "the session API")
+public class SessionApi  {
+
+   private final SessionApiService delegate = SessionApiServiceFactory.getSessionApi();
+
+    @GET
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Get active sessions", notes = "This API is used to retrieve user's session information.", response = AllSessionsDTO.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Successful response"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Bad Request"),
+        
+        @io.swagger.annotations.ApiResponse(code = 401, message = "Unauthorized"),
+        
+        @io.swagger.annotations.ApiResponse(code = 404, message = "Not Found"),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
+
+    public Response getUserSession(@Context MessageContext context)
+    {
+    return delegate.getUserSession(context);
+    }
+    @DELETE
+    @Path("/{sessionId}")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Terminate a session", notes = "This API is used to terminate user's session.", response = void.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Successful response"),
+        
+        @io.swagger.annotations.ApiResponse(code = 204, message = "No content"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Bad Request"),
+        
+        @io.swagger.annotations.ApiResponse(code = 401, message = "Unauthorized"),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
+
+    public Response terminateASession(@Context MessageContext context ,@ApiParam(value = "id of the session",required=true ) @PathParam("sessionId")  String sessionId)
+    {
+     return delegate.terminateASession(context, sessionId);
+    }
+    @DELETE
+    
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @io.swagger.annotations.ApiOperation(value = "Terminate all sessions", notes = "This API is used to terminate user's session.", response = void.class)
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Successful response"),
+        
+        @io.swagger.annotations.ApiResponse(code = 204, message = "No content"),
+        
+        @io.swagger.annotations.ApiResponse(code = 400, message = "Bad Request"),
+        
+        @io.swagger.annotations.ApiResponse(code = 401, message = "Unauthorized"),
+        
+        @io.swagger.annotations.ApiResponse(code = 500, message = "Server Error") })
+
+    public Response terminateAllSessions(@Context MessageContext context)
+    {
+     return delegate.terminateAllSessions(context);
+    }
+}
+

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/gen/java/org/wso2/carbon/identity/local/auth/api/endpoint/SessionApiService.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/gen/java/org/wso2/carbon/identity/local/auth/api/endpoint/SessionApiService.java
@@ -1,0 +1,12 @@
+package org.wso2.carbon.identity.local.auth.api.endpoint;
+
+import org.apache.cxf.jaxrs.ext.MessageContext;
+
+import javax.ws.rs.core.Response;
+
+public abstract class SessionApiService {
+    public abstract Response getUserSession(MessageContext context);
+    public abstract Response terminateASession(MessageContext context, String sessionId);
+    public abstract Response terminateAllSessions(MessageContext context);
+}
+

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/gen/java/org/wso2/carbon/identity/local/auth/api/endpoint/dto/AllSessionsDTO.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/gen/java/org/wso2/carbon/identity/local/auth/api/endpoint/dto/AllSessionsDTO.java
@@ -1,0 +1,45 @@
+package org.wso2.carbon.identity.local.auth.api.endpoint.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+
+
+
+@ApiModel(description = "")
+public class AllSessionsDTO  {
+  
+  
+  
+  private List<SessionDTO> sessions = new ArrayList<SessionDTO>();
+
+  
+  /**
+   * Active applications in session.
+   **/
+  @ApiModelProperty(value = "Active applications in session.")
+  @JsonProperty("sessions")
+  public List<SessionDTO> getSessions() {
+    return sessions;
+  }
+  public void setSessions(List<SessionDTO> sessions) {
+    this.sessions = sessions;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AllSessionsDTO {\n");
+    
+    sb.append("  sessions: ").append(sessions).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/gen/java/org/wso2/carbon/identity/local/auth/api/endpoint/dto/ApplicationDTO.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/gen/java/org/wso2/carbon/identity/local/auth/api/endpoint/dto/ApplicationDTO.java
@@ -1,0 +1,60 @@
+package org.wso2.carbon.identity.local.auth.api.endpoint.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+
+
+
+
+@ApiModel(description = "")
+public class ApplicationDTO  {
+  
+  
+  
+  private String subject = null;
+  
+  
+  private String app = null;
+
+  
+  /**
+   * User name of application.
+   **/
+  @ApiModelProperty(value = "User name of application.")
+  @JsonProperty("subject")
+  public String getSubject() {
+    return subject;
+  }
+  public void setSubject(String subject) {
+    this.subject = subject;
+  }
+
+  
+  /**
+   * Name of application.
+   **/
+  @ApiModelProperty(value = "Name of application.")
+  @JsonProperty("app")
+  public String getApp() {
+    return app;
+  }
+  public void setApp(String app) {
+    this.app = app;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ApplicationDTO {\n");
+    
+    sb.append("  subject: ").append(subject).append("\n");
+    sb.append("  app: ").append(app).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/gen/java/org/wso2/carbon/identity/local/auth/api/endpoint/dto/SessionDTO.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/gen/java/org/wso2/carbon/identity/local/auth/api/endpoint/dto/SessionDTO.java
@@ -1,0 +1,130 @@
+package org.wso2.carbon.identity.local.auth.api.endpoint.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+
+
+
+@ApiModel(description = "")
+public class SessionDTO  {
+  
+  
+  
+  private List<ApplicationDTO> applications = new ArrayList<ApplicationDTO>();
+  
+  
+  private String userAgent = null;
+  
+  
+  private String ip = null;
+  
+  
+  private String loginTime = null;
+  
+  
+  private String lastAccessTime = null;
+  
+  
+  private String sessionId = null;
+
+  
+  /**
+   * Active applications in session.
+   **/
+  @ApiModelProperty(value = "Active applications in session.")
+  @JsonProperty("applications")
+  public List<ApplicationDTO> getApplications() {
+    return applications;
+  }
+  public void setApplications(List<ApplicationDTO> applications) {
+    this.applications = applications;
+  }
+
+  
+  /**
+   * User agent of session.
+   **/
+  @ApiModelProperty(value = "User agent of session.")
+  @JsonProperty("userAgent")
+  public String getUserAgent() {
+    return userAgent;
+  }
+  public void setUserAgent(String userAgent) {
+    this.userAgent = userAgent;
+  }
+
+  
+  /**
+   * Ip address of particular session.
+   **/
+  @ApiModelProperty(value = "Ip address of particular session.")
+  @JsonProperty("ip")
+  public String getIp() {
+    return ip;
+  }
+  public void setIp(String ip) {
+    this.ip = ip;
+  }
+
+  
+  /**
+   * Login time of particular session.
+   **/
+  @ApiModelProperty(value = "Login time of particular session.")
+  @JsonProperty("loginTime")
+  public String getLoginTime() {
+    return loginTime;
+  }
+  public void setLoginTime(String loginTime) {
+    this.loginTime = loginTime;
+  }
+
+  
+  /**
+   * Last access time of particular session.
+   **/
+  @ApiModelProperty(value = "Last access time of particular session.")
+  @JsonProperty("lastAccessTime")
+  public String getLastAccessTime() {
+    return lastAccessTime;
+  }
+  public void setLastAccessTime(String lastAccessTime) {
+    this.lastAccessTime = lastAccessTime;
+  }
+
+  
+  /**
+   * Id of particular session.
+   **/
+  @ApiModelProperty(value = "Id of particular session.")
+  @JsonProperty("sessionId")
+  public String getSessionId() {
+    return sessionId;
+  }
+  public void setSessionId(String sessionId) {
+    this.sessionId = sessionId;
+  }
+
+  
+
+  @Override
+  public String toString()  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SessionDTO {\n");
+    
+    sb.append("  applications: ").append(applications).append("\n");
+    sb.append("  userAgent: ").append(userAgent).append("\n");
+    sb.append("  ip: ").append(ip).append("\n");
+    sb.append("  loginTime: ").append(loginTime).append("\n");
+    sb.append("  lastAccessTime: ").append(lastAccessTime).append("\n");
+    sb.append("  sessionId: ").append(sessionId).append("\n");
+    sb.append("}\n");
+    return sb.toString();
+  }
+}

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/java/org/wso2/carbon/identity/local/auth/api/endpoint/impl/SessionApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/java/org/wso2/carbon/identity/local/auth/api/endpoint/impl/SessionApiServiceImpl.java
@@ -1,0 +1,147 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.identity.local.auth.api.endpoint.impl;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.cxf.jaxrs.ext.MessageContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.local.auth.api.endpoint.SessionApiService;
+import org.wso2.carbon.identity.local.auth.api.endpoint.dto.AllSessionsDTO;
+import org.wso2.carbon.identity.local.auth.api.endpoint.util.AuthAPIEndpointUtil;
+import org.wso2.carbon.identity.user.session.exception.SessionManagementClientException;
+import org.wso2.carbon.identity.user.session.exception.SessionManagementException;
+import org.wso2.carbon.identity.user.session.model.UserSession;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+
+import static org.wso2.carbon.identity.local.auth.api.endpoint.util.AuthAPIEndpointUtil.getSessionManager;
+import static org.wso2.carbon.identity.local.auth.api.endpoint.util.AuthAPIEndpointUtil.getSessionResponse;
+import static org.wso2.carbon.identity.user.session.constant.SessionConstants.ErrorMessages.ERROR_CODE_NO_AUTH_USER_FOUND;
+import static org.wso2.carbon.identity.user.session.constant.SessionConstants.ErrorMessages.ERROR_CODE_SESSION_ID_INVALID;
+import static org.wso2.carbon.identity.user.session.constant.SessionConstants.ErrorMessages.ERROR_CODE_UNEXPECTED;
+import static org.wso2.carbon.identity.user.session.constant.SessionConstants.ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED;
+
+public class SessionApiServiceImpl extends SessionApiService {
+
+    private static final Log log = LogFactory.getLog(SessionApiServiceImpl.class);
+
+    @Override
+    public Response getUserSession(MessageContext context) {
+        try {
+            String sessionId = getSessionContextKey(context.getHttpServletRequest());
+            if (sessionId != null) {
+                UserSession[] userSessions = getSessionManager().viewSession(sessionId);
+                AllSessionsDTO sessionResponse = getSessionResponse(userSessions);
+                return Response.ok().entity(sessionResponse).build();
+            }
+            return Response.ok().build();
+        } catch (SessionManagementClientException e) {
+            return handleBadRequestResponse(e);
+        } catch (SessionManagementException e) {
+            return handleServerErrorResponse(e);
+        } catch (Throwable throwable) {
+            return handleUnexpectedServerError(throwable);
+        }
+    }
+
+    @Override
+    public Response terminateASession(MessageContext context, String sessionId) {
+        try {
+            String currentSessionId = getSessionContextKey(context.getHttpServletRequest());
+            boolean terminateSession = getSessionManager().terminateASession(currentSessionId, sessionId);
+            return Response.ok().entity(terminateSession).build();
+        } catch (SessionManagementClientException e) {
+            return handleBadRequestResponse(e);
+        } catch (SessionManagementException e) {
+            return handleServerErrorResponse(e);
+        } catch (Throwable throwable) {
+            return handleUnexpectedServerError(throwable);
+        }
+    }
+
+    @Override
+    public Response terminateAllSessions(MessageContext context) {
+        try {
+            String sessionId = getSessionContextKey(context.getHttpServletRequest());
+            boolean terminateSession = getSessionManager().terminateAllSession(sessionId);
+            return Response.ok().entity(terminateSession).build();
+        } catch (SessionManagementClientException e) {
+            return handleBadRequestResponse(e);
+        } catch (SessionManagementException e) {
+            return handleServerErrorResponse(e);
+        } catch (Throwable throwable) {
+            return handleUnexpectedServerError(throwable);
+        }
+    }
+
+    /**
+     * Method to get sessionContextKey from http request.
+     *
+     * @param request Http request
+     * @return SessionContextKey of particular session.
+     */
+    private String getSessionContextKey(HttpServletRequest request) {
+        String commonAuthCookie;
+        String sessionContextKey = null;
+        if (FrameworkUtils.getAuthCookie(request) != null) {
+            commonAuthCookie = FrameworkUtils.getAuthCookie(request).getValue();
+            if (commonAuthCookie != null) {
+                sessionContextKey = DigestUtils.sha256Hex(commonAuthCookie);
+            }
+        }
+        return sessionContextKey;
+    }
+
+    private Response handleBadRequestResponse(SessionManagementClientException e) {
+
+        if (isForbiddenError(e)) {
+            throw AuthAPIEndpointUtil.buildForbiddenException(e.getMessage(), e.getErrorCode(), log, e);
+        }
+        if (isNotFoundError(e)) {
+            throw AuthAPIEndpointUtil.buildNotFoundRequestException(e.getMessage(), e.getErrorCode(), log, e);
+        }
+        throw AuthAPIEndpointUtil.buildBadRequestException(e.getMessage(), e.getErrorCode(), log, e);
+    }
+
+    private boolean isForbiddenError(SessionManagementClientException e) {
+
+        return ERROR_CODE_NO_AUTH_USER_FOUND.getCode().equals(e.getErrorCode()) ||
+                ERROR_CODE_USER_NOT_AUTHORIZED.getCode()
+                        .equals(e.getErrorCode());
+    }
+
+    private boolean isNotFoundError(SessionManagementClientException e) {
+
+        return ERROR_CODE_SESSION_ID_INVALID.getCode().equals(e.getErrorCode());
+    }
+
+    private Response handleServerErrorResponse(SessionManagementException e) {
+
+        throw AuthAPIEndpointUtil.buildInternalServerErrorException(e.getErrorCode(), log, e);
+    }
+
+    private Response handleUnexpectedServerError(Throwable e) {
+
+        throw AuthAPIEndpointUtil.buildInternalServerErrorException(ERROR_CODE_UNEXPECTED.getCode(), log, e);
+    }
+
+}

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/java/org/wso2/carbon/identity/local/auth/api/endpoint/util/AuthAPIEndpointUtil.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/java/org/wso2/carbon/identity/local/auth/api/endpoint/util/AuthAPIEndpointUtil.java
@@ -18,18 +18,29 @@
 
 package org.wso2.carbon.identity.local.auth.api.endpoint.util;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.logging.Log;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.local.auth.api.core.AuthManager;
 import org.wso2.carbon.identity.local.auth.api.core.exception.AuthAPIClientException;
 import org.wso2.carbon.identity.local.auth.api.endpoint.constant.AuthEndpointConstants;
+import org.wso2.carbon.identity.local.auth.api.endpoint.dto.AllSessionsDTO;
+import org.wso2.carbon.identity.local.auth.api.endpoint.dto.ApplicationDTO;
 import org.wso2.carbon.identity.local.auth.api.endpoint.dto.ErrorDTO;
+import org.wso2.carbon.identity.local.auth.api.endpoint.dto.SessionDTO;
 import org.wso2.carbon.identity.local.auth.api.endpoint.exception.BadRequestException;
 import org.wso2.carbon.identity.local.auth.api.endpoint.exception.ClientErrorException;
+import org.wso2.carbon.identity.local.auth.api.endpoint.exception.ForbiddenException;
 import org.wso2.carbon.identity.local.auth.api.endpoint.exception.InternalServerErrorException;
 import org.wso2.carbon.identity.local.auth.api.endpoint.exception.NotAcceptableException;
 import org.wso2.carbon.identity.local.auth.api.endpoint.exception.NotFoundException;
+import org.wso2.carbon.identity.user.session.constant.SessionConstants;
+import org.wso2.carbon.identity.user.session.manager.SessionManager;
+import org.wso2.carbon.identity.user.session.model.Application;
+import org.wso2.carbon.identity.user.session.model.UserSession;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -46,6 +57,52 @@ public class AuthAPIEndpointUtil {
                 null);
     }
 
+    public static SessionManager getSessionManager() {
+
+        return (SessionManager) PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                .getOSGiService(SessionManager.class, null);
+    }
+
+
+    public static AllSessionsDTO getSessionResponse(UserSession[] userSessionList) {
+        AllSessionsDTO initiateAllSessionsDTO = new AllSessionsDTO();
+
+        List<SessionDTO> userSessionDTOS = new ArrayList<>();
+
+        for (UserSession userSession : userSessionList) {
+            SessionDTO sessionDTO = new SessionDTO();
+            sessionDTO.setApplications(getApplicationDTO(userSession.getApplications()));
+            sessionDTO.setUserAgent(userSession.getUserAgent());
+            sessionDTO.setIp(userSession.getIp());
+            sessionDTO.setLoginTime(userSession.getLoginTime());
+            sessionDTO.setLastAccessTime(userSession.getLastAccessTime());
+            sessionDTO.setSessionId(DigestUtils.sha256Hex(userSession.getSessionId()));
+            userSessionDTOS.add(sessionDTO);
+        }
+        initiateAllSessionsDTO.setSessions(userSessionDTOS);
+        return initiateAllSessionsDTO;
+    }
+
+    private static List<ApplicationDTO> getApplicationDTO(Application[] applicationList) {
+        List<ApplicationDTO> applicationDTOList = new ArrayList<>();
+
+        for (Application application : applicationList) {
+            ApplicationDTO applicationDTO = new ApplicationDTO();
+            applicationDTO.setApp(application.getAppName());
+            applicationDTO.setSubject(application.getSubject());
+            applicationDTOList.add(applicationDTO);
+        }
+        return applicationDTOList;
+    }
+
+    private static ErrorDTO getErrorDTO(String message, String description, String code) {
+
+        ErrorDTO errorDTO = new ErrorDTO();
+        errorDTO.setCode(code);
+        errorDTO.setMessage(message);
+        errorDTO.setDescription(description);
+        return errorDTO;
+    }
     /**
      * This method is used to create a client exceptions with the known errorCode and message based on error type.
      *
@@ -82,8 +139,8 @@ public class AuthAPIEndpointUtil {
      * @param e Exception object
      * @return BadRequestException with the given errorCode and description.
      */
-    public static BadRequestException buildBadRequestException(String description, String code,  Map<String,String> properties,
-                                                               Log log, Throwable e) {
+    public static BadRequestException buildBadRequestException(String description, String code,
+                                                               Map<String, String> properties, Log log, Throwable e) {
 
         ErrorDTO errorDTO = getErrorDTO(AuthEndpointConstants.STATUS_BAD_REQUEST_MESSAGE_DEFAULT, description, code,
                 properties);
@@ -143,7 +200,7 @@ public class AuthAPIEndpointUtil {
         return new InternalServerErrorException(errorDTO);
     }
 
-    private static ErrorDTO getErrorDTO(String message, String description, String code, Map<String,String>
+    private static ErrorDTO getErrorDTO(String message, String description, String code, Map<String, String>
             properties) {
         ErrorDTO errorDTO = new ErrorDTO();
         errorDTO.setCode(code);
@@ -164,4 +221,50 @@ public class AuthAPIEndpointUtil {
             log.debug(message, throwable);
         }
     }
+
+    /**
+     * This method is used to create a BadRequestException with the known errorCode and message.
+     *
+     * @param description Error Message Desription.
+     * @param code        Error Code.
+     * @return BadRequestException with the given errorCode and description.
+     */
+    public static BadRequestException buildBadRequestException(String description, String code,
+                                                               Log log, Throwable e) {
+
+        ErrorDTO errorDTO = getErrorDTO(SessionConstants.STATUS_BAD_REQUEST_MESSAGE_DEFAULT, description, code);
+        logDebug(AuthEndpointConstants.STATUS_NOT_FOUND_MESSAGE_DEFAULT, log, e);
+        return new BadRequestException(errorDTO);
+    }
+
+    /**
+     * This method is used to create a NotFoundException with the known errorCode and message.
+     *
+     * @param description Error Message Description.
+     * @param code        Error Code.
+     * @return NotFoundException with the given errorCode and description.
+     */
+    public static NotFoundException buildNotFoundRequestException(String description, String code,
+                                                                  Log log, Throwable e) {
+
+        ErrorDTO errorDTO = getErrorDTO(SessionConstants.STATUS_BAD_REQUEST_MESSAGE_DEFAULT, description, code);
+        logDebug(AuthEndpointConstants.STATUS_NOT_FOUND_MESSAGE_DEFAULT, log, e);
+        return new NotFoundException(errorDTO);
+    }
+
+    /**
+     * This method is used to create a Forbidden Exception with the known errorCode and message.
+     *
+     * @param description Error Message Description.
+     * @param code        Error Code.
+     * @return ForbiddenException with the given errorCode and description.
+     */
+    public static ForbiddenException buildForbiddenException(String description, String code,
+                                                             Log log, Throwable e) {
+
+        ErrorDTO errorDTO = getErrorDTO(SessionConstants.STATUS_BAD_REQUEST_MESSAGE_DEFAULT, description, code);
+        logDebug(AuthEndpointConstants.STATUS_NOT_FOUND_MESSAGE_DEFAULT, log, e);
+        return new ForbiddenException(errorDTO);
+    }
+
 }

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/resources/api.identity.local.auth.yaml
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/resources/api.identity.local.auth.yaml
@@ -227,6 +227,94 @@ paths:
       tags:
       - Authentication
 
+  # Endpoint uses to send retrieve session information
+  /session:
+    get:
+      tags:
+        - "Session Information"
+      description: "This API is used to retrieve user's session information."
+      summary: "Get active sessions"
+      operationId: "getUserSession"
+      produces:
+        - "application/json"
+      responses:
+        200:
+          description: "Successful response"
+          schema:
+            $ref: '#/definitions/AllSessions'
+        400:
+          description: "Bad Request"
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: "Unauthorized"
+          schema:
+            $ref: '#/definitions/Error'
+        404:
+          description: "Not Found"
+          schema:
+            $ref: "#/definitions/Error"
+        500:
+          description: "Server Error"
+          schema:
+            $ref: '#/definitions/Error'
+
+    delete:
+      tags:
+        - "Session Termination"
+      description: "This API is used to terminate user's session."
+      summary: "Terminate all sessions"
+      operationId: "terminateAllSessions"
+      responses:
+        200:
+          description: "Successful response"
+        204:
+          description: "No content"
+        400:
+          description: "Bad Request"
+          schema:
+            $ref: "#/definitions/Error"
+        401:
+          description: "Unauthorized"
+          schema:
+            $ref: "#/definitions/Error"
+        500:
+          description: "Server Error"
+          schema:
+            $ref: "#/definitions/Error"
+
+  /session/{sessionId}:
+    delete:
+      tags:
+        - "Session Termination"
+      description: "This API is used to terminate user's session."
+      summary: "Terminate a session"
+      operationId: "terminateASession"
+      parameters:
+        -
+          name: "sessionId"
+          in: "path"
+          description: "id of the session"
+          required: true
+          type: "string"
+      responses:
+        200:
+          description: "Successful response"
+        204:
+          description: "No content"
+        400:
+          description: "Bad Request"
+          schema:
+            $ref: "#/definitions/Error"
+        401:
+          description: "Unauthorized"
+          schema:
+            $ref: "#/definitions/Error"
+        500:
+          description: "Server Error"
+          schema:
+            $ref: "#/definitions/Error"
+
 
 definitions:
   #-----------------------------------------------------
@@ -256,6 +344,58 @@ definitions:
     type: object
     additionalProperties:
       type: object
+
+  #-----------------------------------------------------
+  # The Session Response  object
+  #-----------------------------------------------------
+  Application:
+    type: "object"
+    properties:
+      subject:
+        type: "string"
+        description: "User name of application."
+      app:
+        type: "string"
+        description: "Name of application."
+
+  #-----------------------------------------------------
+  # The Session Response  object
+  #-----------------------------------------------------
+  Session:
+    type: "object"
+    properties:
+      applications:
+        type: "array"
+        description: "Active applications in session."
+        items:
+          $ref: '#/definitions/Application'
+      userAgent:
+        type: "string"
+        description: "User agent of session."
+      ip:
+        type: "string"
+        description: "Ip address of particular session."
+      loginTime:
+        type: "string"
+        description: "Login time of particular session."
+      lastAccessTime:
+        type: "string"
+        description: "Last access time of particular session."
+      sessionId:
+        type: "string"
+        description: "Id of particular session."
+
+  #-----------------------------------------------------
+  # The AllSessions Response  object
+  #-----------------------------------------------------
+  AllSessions:
+    type: "object"
+    properties:
+      sessions:
+        type: "array"
+        description: "Active applications in session."
+        items:
+          $ref: '#/definitions/Session'
 
   #-----------------------------------------------------
   # Error response  object

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/webapp/WEB-INF/beans.xml
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/webapp/WEB-INF/beans.xml
@@ -27,6 +27,7 @@
             <bean class="org.wso2.carbon.identity.local.auth.api.endpoint.AuthenticateApi"/>
             <bean class="org.wso2.carbon.identity.local.auth.api.endpoint.ContextApi"/>
             <bean class="org.wso2.carbon.identity.local.auth.api.endpoint.DataApi"/>
+            <bean class="org.wso2.carbon.identity.local.auth.api.endpoint.SessionApi"/>
             
         </jaxrs:serviceBeans>
         <jaxrs:providers>

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,7 @@
         <carbon.base.imp.pkg.version>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version>
         <identity.inbound.auth.oauth.version>6.0.83</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.oauth.imp.pkg.version>[6.0.0, 7.0.0)</identity.inbound.auth.oauth.imp.pkg.version>
+        <carbon.identity.user.session.version>1.0.1</carbon.identity.user.session.version>
 
         <cxf-bundle.version>3.2.8</cxf-bundle.version>
         <jackson.version>1.9.13</jackson.version>


### PR DESCRIPTION
## Purpose
This PR contains user session management rest API endpoint.
endpoints:
GET auth/v1.2/session - view all active sessions
DELETE auth/v1.2/session -delete all active sessions.
DELETE auth/v1.2/sesion/{sessionId} - delete a particular session.

Depends on:
Add user session api core component and stub #290
