### PR TITLE
Make the pax logging as provided

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/pom.xml
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/pom.xml
@@ -149,6 +149,7 @@
         <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-codec.wso2</groupId>


### PR DESCRIPTION
## Purpose
Make the pax logging as provided as it is not needed to be packed with the war. Fix: https://github.com/wso2/product-is/issues/6340