### PR TITLE
Add auth context expiry validation to the API

### DIFF
--- a/components/org.wso2.carbon.api.server.local.auth.api/src/main/java/org/wso2/carbon/identity/local/auth/api/endpoint/impl/ContextApiServiceImpl.java
+++ b/components/org.wso2.carbon.api.server.local.auth.api/src/main/java/org/wso2/carbon/identity/local/auth/api/endpoint/impl/ContextApiServiceImpl.java
@@ -41,6 +41,14 @@ public class ContextApiServiceImpl extends ContextApiService {
 
         AuthenticationContext context = FrameworkUtils.getAuthenticationContextFromCache(sessionKey);
         if (context != null) {
+            if (FrameworkUtils.isAuthenticationContextExpiryEnabled() &&
+                    (FrameworkUtils.getCurrentStandardNano() > context.getExpiryTime())) {
+                ErrorDTO errorDTO = new ErrorDTO();
+                errorDTO.setCode("404");
+                errorDTO.setMessage("Expired Authentication Context");
+                errorDTO.setDescription("Authentication context has expired");
+                return Response.status(Response.Status.NOT_FOUND).entity(errorDTO).build();
+            }
             Map<String, Serializable> endpointParams = context.getEndpointParams();
             if (StringUtils.isNotBlank(parameters)) {
                 String[] paramArray = parameters.split(",");

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
 
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
-        <carbon.identity.framework.version>5.20.321</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.28</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version>[5.20.321, 6.0.0)</carbon.identity.framework.imp.pkg.version>
         <carbon.user.api.imp.pkg.version>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version>
         <carbon.base.imp.pkg.version>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version>


### PR DESCRIPTION
## Purpose
With the fix for https://github.com/wso2/carbon-identity-framework/pull/4327, we will be introducing an expiry time and related validations to the AuthenticationContext object. This change need to be reflected at the auth API.

## Related Issues
- https://github.com/wso2/product-is/issues/15140