### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <url>https://github.com/wso2-extensions/identity-local-auth-api.git</url>
         <developerConnection>scm:git:https://github.com/wso2-extensions/identity-local-auth-api.git</developerConnection>
         <connection>scm:git:https://github.com/wso2-extensions/identity-local-auth-api.git</connection>
-        <tag>v2.5.5</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>
@@ -278,12 +278,12 @@
 
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
-        <carbon.identity.framework.version>5.20.321</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version>[5.20.321, 6.0.0)</carbon.identity.framework.imp.pkg.version>
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version>[6.0.0, 7.0.0)</carbon.identity.framework.imp.pkg.version>
         <carbon.user.api.imp.pkg.version>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version>
         <carbon.base.imp.pkg.version>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version>
-        <identity.inbound.auth.oauth.version>6.2.18</identity.inbound.auth.oauth.version>
-        <identity.inbound.auth.oauth.imp.pkg.version>[6.2.18, 7.0.0)</identity.inbound.auth.oauth.imp.pkg.version>
+        <identity.inbound.auth.oauth.version>7.0.0</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.imp.pkg.version>[7.0.0, 8.0.0)</identity.inbound.auth.oauth.imp.pkg.version>
 
         <cxf-bundle.version>3.3.7</cxf-bundle.version>
         <jackson.version>1.9.13</jackson.version>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16