### PR TITLE
Add changes to use the new login resolver concept

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.api.core/pom.xml
+++ b/components/org.wso2.carbon.identity.local.auth.api.core/pom.xml
@@ -75,7 +75,7 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
+            <artifactId>org.wso2.carbon.identity.login.resolver.mgt</artifactId>
         </dependency>
     </dependencies>
 
@@ -120,7 +120,7 @@
                             org.wso2.carbon.identity.oauth.cache; version="${identity.inbound.auth.oauth.imp.pkg.version}",
                             org.wso2.carbon.identity.oauth.common;
                             version="${identity.inbound.auth.oauth.imp.pkg.version}",
-                            org.wso2.carbon.identity.multi.attribute.login.mgt.*;
+                            org.wso2.carbon.identity.login.resolver.mgt;
                             version="${carbon.identity.framework.imp.pkg.version}",
                         </Import-Package>
                         <Export-Package>

--- a/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/AuthManagerImpl.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/AuthManagerImpl.java
@@ -37,7 +37,7 @@ import org.wso2.carbon.identity.local.auth.api.core.model.AuthnMessageContext;
 import org.wso2.carbon.identity.local.auth.api.core.model.AuthnRequest;
 import org.wso2.carbon.identity.local.auth.api.core.model.AuthnResponse;
 import org.wso2.carbon.identity.local.auth.api.core.model.AuthnStatus;
-import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
+import org.wso2.carbon.identity.login.resolver.mgt.ResolvedUserResult;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
@@ -144,8 +144,8 @@ public class AuthManagerImpl implements AuthManager {
         String userTenantDomain = MultitenantUtils.getTenantDomain(username);
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         UserStoreManager userStoreManager = getUserStoreManager(userTenantDomain);
-        ResolvedUserResult resolvedUserResult = FrameworkUtils.
-                processMultiAttributeLoginIdentification(tenantAwareUsername, userTenantDomain);
+        ResolvedUserResult resolvedUserResult = FrameworkUtils.processLoginResolverIdentification(tenantAwareUsername,
+                userTenantDomain);
         if (resolvedUserResult != null &&  ResolvedUserResult.UserResolvedStatus.SUCCESS.
                 equals(resolvedUserResult.getResolvedStatus())) {
             tenantAwareUsername = resolvedUserResult.getUser().getUsername();

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
+                <artifactId>org.wso2.carbon.identity.login.resolver.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
         </dependencies>
@@ -278,7 +278,7 @@
 
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
-        <carbon.identity.framework.version>5.25.28</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.83-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version>[5.20.321, 6.0.0)</carbon.identity.framework.imp.pkg.version>
         <carbon.user.api.imp.pkg.version>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version>
         <carbon.base.imp.pkg.version>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version>


### PR DESCRIPTION
## Purpose
> Add changes to use the new resolver concept which are introduced with the PRs https://github.com/wso2/carbon-identity-framework/pull/4404 and https://github.com/wso2-extensions/identity-governance/pull/652. Resolves: https://github.com/wso2/product-is/issues/15439.

## Goals
> The goal of this process is to make the WSO2 Identity Server extensible in-terms of having the ability to have multiple login resolvers and providing the user to select the login resolver to be executed from the user interface.

## Approach
> Deprecate the multi attribute specific login resolver since the introduction of the generic login resolver serves the same purpose with additional configurations to provide more extensibility.

## Release note
> This improvement will add the ability to resolve multiple login resolvers and add the changes to the new handler (alternative to the multi attribute login handler) so that the user can select a login resolver through the management console resident identity provider configurations. By default, the priority is provided to the login resolver that corresponds to the multi attribute login functionality. Users can introduce new login resolvers and decide on which resolver to be used.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> https://github.com/wso2/carbon-identity-framework/pull/4404, https://github.com/wso2-extensions/identity-governance/pull/652.

## Test environment
> Ubuntu 20.04.3 LTS, JDK 11.0.12, Maven 3.6.3 
 