### PR TITLE
Remove data from cache based on removeOnConsume attribute in Cache entry

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/impl/SessionDataKeyConsentParamResolverImpl.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/impl/SessionDataKeyConsentParamResolverImpl.java
@@ -47,7 +47,7 @@ public class SessionDataKeyConsentParamResolverImpl implements ParameterResolver
             if (filter != null && !filter.isEmpty()) {
                 endpointParams.keySet().retainAll(filter);
             }
-            if (deleteOnRead) {
+            if (deleteOnRead || cacheEntry.isRemoveOnConsume()) {
                 cacheEntry.getEndpointParams().keySet().removeAll(endpointParams.keySet());
                 SessionDataCache.getInstance().clearCacheEntry(cacheKey);
                 SessionDataCache.getInstance().addToCache(cacheKey, cacheEntry);

--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
         <carbon.identity.framework.imp.pkg.version>[5.20.321, 7.0.0)</carbon.identity.framework.imp.pkg.version>
         <carbon.user.api.imp.pkg.version>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version>
         <carbon.base.imp.pkg.version>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version>
-        <identity.inbound.auth.oauth.version>6.2.18</identity.inbound.auth.oauth.version>
+        <identity.inbound.auth.oauth.version>6.11.58</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.oauth.imp.pkg.version>[6.2.18, 7.0.0)</identity.inbound.auth.oauth.imp.pkg.version>
 
         <cxf-bundle.version>3.3.7</cxf-bundle.version>


### PR DESCRIPTION
## Purpose
-  We need to clear the cache, after reading the consent related data from the context data API when the external consent page is enabled.
- When data adding to the cache in external consent page flow, we  are setting the `removeOnConume= true`
- After reading the consent related data from external side once, We remove the related data from the cache. 

### Should merge after

https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2072