### PR TITLE
Make 'Local Auth API' component activation log level to debug

### DIFF
--- a/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/internal/AuthAPIServiceComponent.java
+++ b/components/org.wso2.carbon.identity.local.auth.api.core/src/main/java/org/wso2/carbon/identity/local/auth/api/core/internal/AuthAPIServiceComponent.java
@@ -65,7 +65,7 @@ public class AuthAPIServiceComponent {
             bundleContext.registerService(ParameterResolver.class, new SessionDataKeyParamResolverImpl(), null);
             bundleContext.registerService(ParameterResolver.class, new SessionDataKeyConsentParamResolverImpl(), null);
             bundleContext.registerService(ParameterResolver.class, new AuthenticationErrorParamResolver(), null);
-            log.info("Auth API Service Component  is activated.");
+            log.debug("Auth API Service Component  is activated.");
         } catch (Throwable e) {
             log.error("Error while activating Auth API Service Component.", e);
         }


### PR DESCRIPTION
## Purpose

$subject to avoid unnecessary logs to be printed during the product startup.

Related to,
- https://github.com/wso2/product-is/issues/20778