### PR TITLE
Remove cors filter

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-m2
         with:

--- a/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/webapp/WEB-INF/web.xml
+++ b/components/org.wso2.carbon.identity.local.auth.api.endpoint/src/main/webapp/WEB-INF/web.xml
@@ -27,15 +27,6 @@
     <display-name>WSO2 Identity Server Authentication API</display-name>
     <description>WSO2 Identity Server Authentication API</description>
 
-    <filter>
-        <filter-name>CORS</filter-name>
-        <filter-class>com.thetransactioncompany.cors.CORSFilter</filter-class>
-    </filter>
-    <filter-mapping>
-        <filter-name>CORS</filter-name>
-        <url-pattern>/*</url-pattern>
-    </filter-mapping>
-
     <servlet>
         <servlet-name>CXFServlet</servlet-name>
         <servlet-class>


### PR DESCRIPTION
## Purpose
> The identity server uses a CORS filter which is by default activated for all tomcat requests. However the `WSO2 Identity Server Authentication API` currently has it's own implementation for a CORS filter. This causes duplicate "Access-Control-Allow-Origin" and "Access-Control-Allow-Credentials" headers. 
> This PR removes the CORs filter from the `WSO2 Identity Server Authentication API`. 

## Related Issue 
- https://github.com/wso2/product-is/issues/23419