### PR TITLE
Update pr-builder.yml. Bump actions version.

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Adopt JDK 8
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
## Purpose
> actions/cache@v2 is deprecated. actions/cache@v3 is temporarily disabled. Therefore bumping the version to actions/cache@v4.

## Related Issue 
- https://github.com/wso2/product-is/issues/23500