### PR TITLE
Bump dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
 
         <nimbusds.version>9.37.3.wso2v1</nimbusds.version>
         <nimbusds.imp.pkg.version>[9.0.0, 11)</nimbusds.imp.pkg.version>
-        <json-smart.version>2.4.7</json-smart.version>
+        <json-smart.version>2.6.0</json-smart.version>
 
         <eclipse.osgi.version>3.5.100.v20160504-1419</eclipse.osgi.version>
         <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
@@ -278,7 +278,7 @@
 
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
-        <carbon.identity.framework.version>5.25.28</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.728</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version>[5.20.321, 6.0.0)</carbon.identity.framework.imp.pkg.version>
         <carbon.user.api.imp.pkg.version>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version>
         <carbon.base.imp.pkg.version>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version>


### PR DESCRIPTION
This pull request updates two dependencies in the `pom.xml` file to newer versions. These are minor version bumps intended to keep the project up-to-date with upstream changes.

Dependency upgrades:

* Updated the `json-smart.version` property from `2.4.7` to `2.6.0`, ensuring the project uses the latest features and bug fixes from the JSON Smart library.
* Updated the `carbon.identity.framework.version` property from `5.25.28` to `5.25.728` to incorporate the latest changes from the Carbon Identity Framework.